### PR TITLE
Fix inconsistently used bare trait objects

### DIFF
--- a/core/src/inventory.rs
+++ b/core/src/inventory.rs
@@ -17,7 +17,7 @@ pub fn build_registry() -> Registry {
 /// This is instantiated once for each castable trait. It describes how a trait
 /// can insert itself into the global table.
 pub struct EntryBuilder {
-    pub insert: Box<Fn(&mut Registry)>,
+    pub insert: Box<dyn Fn(&mut Registry)>,
 }
 
 impl EntryBuilder {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -137,7 +137,7 @@ impl<To: ?Sized + 'static> CastIntoTrait<To> {
 /// An entry in the table for a particular castable trait. Stores methods to
 /// cast into one particular struct that implements the trait.
 pub struct ImplEntry<DynTrait: ?Sized> {
-    pub cast_box: fn(Box<Any>) -> Result<Box<DynTrait>, Box<Any>>,
+    pub cast_box: fn(Box<dyn Any>) -> Result<Box<DynTrait>, Box<dyn Any>>,
     pub cast_mut: fn(&mut dyn Any) -> Option<&mut DynTrait>,
     pub cast_ref: fn(&dyn Any) -> Option<&DynTrait>,
     pub tid: TypeId,

--- a/traitcast/src/tests.rs
+++ b/traitcast/src/tests.rs
@@ -65,8 +65,8 @@ use crate::Traitcast;
 
 #[test]
 fn test_traitcast() {
-    let mut x: Box<Any> = Box::new(A { x: 0 });
-    let mut y: Box<Any> = Box::new(B { y: 1 });
+    let mut x: Box<dyn Any> = Box::new(A { x: 0 });
+    let mut y: Box<dyn Any> = Box::new(B { y: 1 });
 
     {
         // Can cast from Any to Bar


### PR DESCRIPTION
Fix several rustc warnings about using bare trait objects