### PR TITLE
Convert `core` to a `no_std` crate

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/bch29/traitcast"
 [dependencies]
 anymap = "0.12.*"
 inventory = { version = "0.1.*", optional = true }
+hashbrown = "0.6.3"
 
 [dev-dependencies]
 inventory = "0.1.*"

--- a/core/src/inventory.rs
+++ b/core/src/inventory.rs
@@ -3,6 +3,7 @@ This module defines helper types for using `traitcast` along with the
 `inventory` crate. Requires the `use_inventory` feature.
 */
 use crate::{CastIntoTrait, ImplEntry, Registry};
+use alloc::boxed::Box;
 
 /// Makes a trait registry by collecting EntryBuilders with the `inventory`
 /// crate.
@@ -28,7 +29,7 @@ impl EntryBuilder {
         Entry: inventory::Collect + AsRef<ImplEntry<To>>,
         To: 'static + ?Sized,
     {
-        use std::iter::FromIterator;
+        use core::iter::FromIterator;
         EntryBuilder {
             insert: Box::new(|master| {
                 master.insert(CastIntoTrait::from_iter(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,9 @@ global registry. This makes it more flexible at the cost of having to create
 a registry and pass it around. If you do not want to do that, use the root
 `traitcast` module which provides a convenient global registry.
 */
+#![no_std]
+
+extern crate alloc;
 
 #[cfg(feature = "use_inventory")]
 pub mod inventory;
@@ -11,8 +14,9 @@ pub mod inventory;
 // #[cfg(test)]
 // pub mod tests;
 
-use std::any::{Any, TypeId};
-use std::collections::HashMap;
+use alloc::boxed::Box;
+use core::any::{Any, TypeId};
+use hashbrown::HashMap;
 
 /// A registry defining how to cast into some set of traits.
 pub struct Registry {
@@ -71,7 +75,7 @@ impl<DynTrait: ?Sized> CastIntoTrait<DynTrait> {
     }
 }
 
-impl<DynTrait: ?Sized> std::iter::FromIterator<ImplEntry<DynTrait>>
+impl<DynTrait: ?Sized> core::iter::FromIterator<ImplEntry<DynTrait>>
     for CastIntoTrait<DynTrait>
 {
     fn from_iter<T>(iter: T) -> Self
@@ -173,7 +177,7 @@ pub trait TraitcastFrom {
     fn as_any_box(self: Box<Self>) -> Box<dyn Any>;
 
     /// Get the trait object's dynamic type id.
-    fn type_id(&self) -> std::any::TypeId {
+    fn type_id(&self) -> core::any::TypeId {
         self.as_any_ref().type_id()
     }
 }


### PR DESCRIPTION
This pull request makes the necessary changes to allow building in a `no_std` environment. 

Depends on https://github.com/chris-morgan/anymap/pull/39